### PR TITLE
COR-354: Upgrade the versions of pdfbox, poi, tika

### DIFF
--- a/exo.core.component.document/src/main/java/org/exoplatform/services/document/impl/PDFDocumentReader.java
+++ b/exo.core.component.document/src/main/java/org/exoplatform/services/document/impl/PDFDocumentReader.java
@@ -191,7 +191,7 @@ public class PDFDocumentReader extends BaseDocumentReader
                      {
                         pdDocument.decrypt("");
                      }
-                     catch (InvalidPasswordException e)
+                     catch (IOException e)
                      {
                         throw new DocumentReadException("The pdf document is encrypted.", e);
                      }

--- a/exo.core.component.document/src/test/java/org/exoplatform/services/document/tika/TestMSExcelOnTikaDocumentReader.java
+++ b/exo.core.component.document/src/test/java/org/exoplatform/services/document/tika/TestMSExcelOnTikaDocumentReader.java
@@ -49,7 +49,10 @@ public class TestMSExcelOnTikaDocumentReader extends BaseStandaloneTest
          String text = service.getDocumentReader("application/excel").getContentAsText(is);
 
          String expected =
-            "Sheet2 Ronaldo Eric Cantona Kaka Ronaldonho Sheet1 ID Group Functionality Executor Begin End "
+            "Sheet2 Ronaldo Eric Cantona Kaka Ronaldonho "
+               + "&C&\"Times New Roman,Regular\"&12&A "
+               + "&C&\"Times New Roman,Regular\"&12Page &P "
+               + "Sheet1 ID Group Functionality Executor Begin End "
                + "Tested XNNL XNNL Xay dung vung quan li nguyen lieu NamPH 2/2/05 10/02/2005 "
                + "Tested XNNL XNNL XNNL_HAVEST NamPH 1223554 10/01/2005 "
                + "Tested XNNL XNNL XNNL_PIECE_OF_GROUND NamPH 10/12/05 10/02/2005 "
@@ -86,7 +89,10 @@ public class TestMSExcelOnTikaDocumentReader extends BaseStandaloneTest
 
          String text = buf.toString();
          String expected =
-            "Sheet2 Ronaldo Eric Cantona Kaka Ronaldonho Sheet1 ID Group Functionality Executor Begin End "
+            "Sheet2 Ronaldo Eric Cantona Kaka Ronaldonho "
+               + "&C&\"Times New Roman,Regular\"&12&A "
+               + "&C&\"Times New Roman,Regular\"&12Page &P "
+               + "Sheet1 ID Group Functionality Executor Begin End "
                + "Tested XNNL XNNL Xay dung vung quan li nguyen lieu NamPH 2/2/05 10/02/2005 "
                + "Tested XNNL XNNL XNNL_HAVEST NamPH 1223554 10/01/2005 "
                + "Tested XNNL XNNL XNNL_PIECE_OF_GROUND NamPH 10/12/05 10/02/2005 "

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
          <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.10</version>
          </dependency>
          
          <dependency>
@@ -251,19 +251,19 @@
          <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>3.10.1</version>
+            <version>3.13</version>
          </dependency>
 
          <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
-            <version>3.10.1</version>
+            <version>3.13</version>
          </dependency>
 
          <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.10.1</version>
+            <version>3.13</version>
          </dependency>
 
          <dependency>
@@ -311,13 +311,13 @@
         <dependency>
            <groupId>org.apache.tika</groupId>
            <artifactId>tika-core</artifactId>
-           <version>1.5</version>
+           <version>1.11</version>
         </dependency>
 
         <dependency>
            <groupId>org.apache.tika</groupId>
            <artifactId>tika-parsers</artifactId>
-           <version>1.5</version>
+           <version>1.11</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fix description:
- Update the versions in the main pom
- Remove InvalidPasswordExcetion in PDDocument.decrypt(). This change exists since pdfbox 1.8.6 (PDFBOX-1474).
- TIKA-1400 (tika 1.10) extracts the header and footer of Excel file (.xls). The information is then put into class "outside".
  The output of TestMSExcelOnTikaDocumentReader must be therefore updated.
