### PR TITLE
EXOGTN-2231 Make update login time asynchronous

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/UserHandler.java
@@ -264,6 +264,16 @@ public interface UserHandler
    boolean authenticate(String username, String password) throws Exception, DisabledUserException;
 
    /**
+    * Determines whether the API should update the Last Login time after
+    * authentication or not.
+    * 
+    * @return true if the last login time should be updated on login, else false.
+    */
+   default boolean isUpdateLastLoginTime() {
+     return true;
+   };
+
+   /**
     * This method is used to register an user event listener
     * 
     * @param listener the user event listener to register


### PR DESCRIPTION
Add a new method in OrganizationService API to determines whether the update login time should be updated after user login or not.
Default behavior = true.
