### PR TITLE
Upgrade to Hibernate 5

### DIFF
--- a/exo.core.component.database/pom.xml
+++ b/exo.core.component.database/pom.xml
@@ -155,7 +155,12 @@
          <artifactId>ow2-jta-1.1-spec</artifactId>
          <scope>provided</scope>
       </dependency>
-  </dependencies>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-core</artifactId>
+         <version>5.4.10.Final</version>
+      </dependency>
+   </dependencies>
    
    <build>
      <plugins>   

--- a/exo.core.component.database/src/main/java/org/exoplatform/services/database/impl/HibernateConfigurationImpl.java
+++ b/exo.core.component.database/src/main/java/org/exoplatform/services/database/impl/HibernateConfigurationImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.service.ServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 
 /**
  * Created by The eXo Platform SAS .
@@ -45,7 +45,7 @@ public class HibernateConfigurationImpl extends Configuration
    public SessionFactory buildSessionFactory() throws HibernateException
    {
 
-      ServiceRegistry servReg = new ServiceRegistryBuilder().applySettings(getProperties()).buildServiceRegistry();
+      ServiceRegistry servReg = new StandardServiceRegistryBuilder().applySettings(getProperties()).build();
       SessionFactory sessionFactory = buildSessionFactory(servReg);
 
       return sessionFactory;


### PR DESCRIPTION
We tried to update hibernate-core up to 5.4.10.Final. Changed dependency and updated HibernateConfigurationImpl in order to fit the new hibernate, but we ran into problems. We stalled due to lack of needed classes (didn't find a replacement for them (org.hibernate.cache.spi.GeneralDataRegion, org.hibernate.cache.spi.EntityRegion, org.hibernate.cache.spi.NaturalIdRegion, org.hibernate.cache.spi.CollectionRegion, org.hibernate.cache.spi.CacheDataDescription, org.hibernate.cache.spi.access.EntityRegionAccessStrategy)).